### PR TITLE
使用日志门面代替控制台打印

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ maven项目可直接导入:
 #### 2. 快速入门:
 1. 引入Jar包;
 2. `@MagicClass`对当前类进行全局配置
-2. `@MagicField`对需要转换的JAVA对象属性进行标注,支持对象组合嵌套
-3. 使用`MagicByte.pack()`或则`MagicByte.unpack()`对数据或对象进行快速的序列化或反序列化
+3. `@MagicField`对需要转换的JAVA对象属性进行标注,支持对象组合嵌套
+4. 使用`MagicByte.pack()`或则`MagicByte.unpack()`对数据或对象进行快速的序列化或反序列化
+5. 项目使用 slf4j 输出日志，未引入日志框架，请自行搭配日志框架进行使用
 
 #### 3. 代码示例
 下面的对象中, 共有 Student 和 School 两个对象

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,26 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.24</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <!-- 日志门面 -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.6</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- 测试工具 -->
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>

--- a/src/main/java/com/github/misterchangray/core/util/DynamicByteBuffer.java
+++ b/src/main/java/com/github/misterchangray/core/util/DynamicByteBuffer.java
@@ -330,12 +330,7 @@ public class DynamicByteBuffer {
             }
         }
         if(Objects.nonNull(this.checkCodeFieldWrapper) && Objects.nonNull(magicChecker)) {
-            long val = 0;
-            try {
-                val = magicChecker.calcCheckCode(this.array());
-            } catch (Exception ae) {
-                throw ae;
-            }
+            long val = magicChecker.calcCheckCode(this.array());
             try {
                 fieldMetaInfo = this.checkCodeFieldWrapper.getFieldMetaInfo();
                 fieldMetaInfo.getWriter().writeToBuffer(this,   ConverterUtil.toTargetObject(fieldMetaInfo.getType(), val),

--- a/src/main/java/com/github/misterchangray/core/util/DynamicByteBuffer.java
+++ b/src/main/java/com/github/misterchangray/core/util/DynamicByteBuffer.java
@@ -5,6 +5,7 @@ import com.github.misterchangray.core.clazz.FieldMetaInfo;
 import com.github.misterchangray.core.clazz.FieldMetaInfoWrapper;
 import com.github.misterchangray.core.enums.TypeEnum;
 import com.github.misterchangray.core.exception.MagicParseException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -17,6 +18,7 @@ import java.util.Objects;
  * @author: Ray.chang
  * @create: 2021-12-17 15:05
  **/
+@Slf4j
 public class DynamicByteBuffer {
     private ByteBuffer byteBuffer;
     private boolean isDynamic;
@@ -324,7 +326,7 @@ public class DynamicByteBuffer {
                 fieldMetaInfo = this.lengthFieldWrapper.getFieldMetaInfo();
                 fieldMetaInfo.getWriter().writeToBuffer(this,   ConverterUtil.toTargetObject(fieldMetaInfo.getType(), this.position()), null, this.lengthFieldWrapper.getStartOffset());
             } catch (IllegalAccessException e) {
-                e.printStackTrace();
+                log.error(e.getMessage(), e);
             }
         }
         if(Objects.nonNull(this.checkCodeFieldWrapper) && Objects.nonNull(magicChecker)) {
@@ -339,7 +341,7 @@ public class DynamicByteBuffer {
                 fieldMetaInfo.getWriter().writeToBuffer(this,   ConverterUtil.toTargetObject(fieldMetaInfo.getType(), val),
                         null, this.checkCodeFieldWrapper.getStartOffset());
             } catch (IllegalAccessException e) {
-                e.printStackTrace();
+                log.error(e.getMessage(), e);
             }
         }
     }


### PR DESCRIPTION
# 修改
1. 原先的异常信息直接在控制台打印，对于使用日志框架的系统不友好，不便于定位问题。因为，使用 slf4j 门面输出日志，搭配系统引用的日志框架，提升异常输出的灵活性
2. 移除冗余的异常处理