### PR TITLE
Refactor: 修改 MConverter 的默认方法

### DIFF
--- a/src/main/java/com/github/misterchangray/core/intf/MConverter.java
+++ b/src/main/java/com/github/misterchangray/core/intf/MConverter.java
@@ -1,42 +1,40 @@
 package com.github.misterchangray.core.intf;
 
+import com.github.misterchangray.core.MagicByte;
 import com.github.misterchangray.core.clazz.MResult;
 
 /**
- *
+ * @param <T>
  * @description: 此类用于实现自己的序列化逻辑
  * @author: Ray.chang
  * @create: 2023-02-08 15:11
- * @param <T>
  */
 public interface MConverter<T> {
 
     /**
-     *
      * 将字节数据打包为对象
      * 注意这里是全部的字节数据
+     *
      * @param nextReadIndex 起始位置，即在此之前的都已读取
-     * @param fullBytes 完整字节数据
-     * @param attachParams 附加参数
-     * @param clz 打包对象所属类
-     * @param fieldObj 当前处理的对象
-     * @param rootObj 处理的根基对象
-     * @return
+     * @param fullBytes     完整字节数据
+     * @param attachParams  附加参数
+     * @param clz           打包对象所属类
+     * @param fieldObj      当前处理的对象
+     * @param rootObj       处理的根基对象
+     * @return 反序列化用的数据长度和对象
      */
-    default MResult<T> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object fieldObj, Object rootObj) {
-        return MResult.build(0, null);
-    }
+    MResult<T> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object fieldObj, Object rootObj);
 
     /**
      * 将对象拆包为字节
-     *
+     * <p>
      * magicByte 会将返回的字节数据整合到全部数据集中
-     * @param object
+     *
+     * @param object       泛型对应类的实例
      * @param attachParams 附加参数
-     * @return
-     * @throws IllegalAccessException
+     * @return 序列化的二进制数据
      */
     default byte[] unpack(T object, String[] attachParams) {
-        return null;
-    };
+        return MagicByte.unpackToByte(object);
+    }
 }


### PR DESCRIPTION
# 修改
1. 由于提供了默认实现，导致在编写的时候编译器不会提示需要实现方法，如果不清楚可能会忽视重写方法导致默认方法返回 null 造成空指针异常，因此修改方法，对于反序列化，要求必须实现；序列化方法如果不实现则默认直接调用 MagicByte.unpackToByte(object) 方法