### PR TITLE
MResult 的方法实现泛型检查

### DIFF
--- a/src/main/java/com/github/misterchangray/core/MagicByte.java
+++ b/src/main/java/com/github/misterchangray/core/MagicByte.java
@@ -133,7 +133,7 @@ public class MagicByte {
         res.put(data);
         res.position(0);
 
-        Object o = packer.packObject(res, clazz, checker);
+        T o = packer.packObject(res, clazz, checker);
         return MResult.build(res.position(), o);
     }
 

--- a/src/main/java/com/github/misterchangray/core/clazz/ClassParser.java
+++ b/src/main/java/com/github/misterchangray/core/clazz/ClassParser.java
@@ -4,7 +4,6 @@ package com.github.misterchangray.core.clazz;
 import com.github.misterchangray.core.annotation.MagicClass;
 import com.github.misterchangray.core.annotation.MagicConverter;
 import com.github.misterchangray.core.enums.TypeEnum;
-import com.github.misterchangray.core.exception.InvalidParameterException;
 import com.github.misterchangray.core.intf.MConverter;
 import com.github.misterchangray.core.util.AnnotationUtil;
 import com.github.misterchangray.core.util.ExceptionUtil;
@@ -76,7 +75,7 @@ public class ClassParser {
     private void linkCustomConverter(ClassMetaInfo classMetaInfo, Class<?> clazz) {
         MagicConverter magicConverter = AnnotationUtil.getMagicClassConverterAnnotation(clazz);
         if(Objects.nonNull(magicConverter)) {
-            MConverter mConverter = null;
+            MConverter<?> mConverter = null;
             try {
                 mConverter = magicConverter.converter().getDeclaredConstructor().newInstance();
             } catch (IllegalAccessException ae) {

--- a/src/main/java/com/github/misterchangray/core/clazz/CustomConverterInfo.java
+++ b/src/main/java/com/github/misterchangray/core/clazz/CustomConverterInfo.java
@@ -34,7 +34,7 @@ public class CustomConverterInfo {
         this.handleCollection = handleCollection;
     }
 
-    public boolean isFixsize() {
+    public boolean isFixSize() {
         return this.fixSize >= 0;
     }
 

--- a/src/main/java/com/github/misterchangray/core/clazz/CustomConverterInfo.java
+++ b/src/main/java/com/github/misterchangray/core/clazz/CustomConverterInfo.java
@@ -6,7 +6,6 @@ public class CustomConverterInfo {
 
     /**
      * 附加参数
-     * @return
      */
     private String[] attachParams;
 
@@ -19,7 +18,6 @@ public class CustomConverterInfo {
 
     /**
      * 固定长度
-     * @return
      */
     private int fixSize ;
 

--- a/src/main/java/com/github/misterchangray/core/clazz/CustomConverterInfo.java
+++ b/src/main/java/com/github/misterchangray/core/clazz/CustomConverterInfo.java
@@ -14,7 +14,7 @@ public class CustomConverterInfo {
     /**
      * 自定义序列化转换器
      */
-    private MConverter converter;
+    private MConverter<?> converter;
 
 
     /**
@@ -38,12 +38,12 @@ public class CustomConverterInfo {
         return this.fixSize >= 0;
     }
 
-
+    // todo 这里如果加上<?> 会导致调用的方法无法使用 Object 作为入参对象，后续需要解决
     public MConverter getConverter() {
         return converter;
     }
 
-    public void setConverter(MConverter converter) {
+    public void setConverter(MConverter<?> converter) {
         this.converter = converter;
     }
 
@@ -63,7 +63,7 @@ public class CustomConverterInfo {
         this.attachParams = attachParams;
     }
 
-    public CustomConverterInfo(String[] attachParams, MConverter converter, int fixSize, boolean handleCollection) {
+    public CustomConverterInfo(String[] attachParams, MConverter<?> converter, int fixSize, boolean handleCollection) {
         this.attachParams = attachParams;
         this.converter = converter;
         this.fixSize = fixSize;

--- a/src/main/java/com/github/misterchangray/core/clazz/FieldParser.java
+++ b/src/main/java/com/github/misterchangray/core/clazz/FieldParser.java
@@ -181,7 +181,7 @@ public class FieldParser {
         MagicConverter magicConverter = AnnotationUtil.getMagicFieldConverterAnnotation(field);
         if(Objects.isNull(magicConverter)) return;
 
-        Class clazz = field.getType();
+        Class<?> clazz = field.getType();
         if(TypeManager.isCollection(TypeManager.getType(clazz))) {
             fieldMetaInfo.getGenericsField().setType(TypeEnum.CUSTOM);
             fieldMetaInfo.getGenericsField().setWriter(TypeManager.newWriter(fieldMetaInfo.getGenericsField()));

--- a/src/main/java/com/github/misterchangray/core/clazz/FieldParser.java
+++ b/src/main/java/com/github/misterchangray/core/clazz/FieldParser.java
@@ -199,7 +199,7 @@ public class FieldParser {
             }
         }
 
-        MConverter mConverter = null;
+        MConverter<?> mConverter = null;
         try {
             mConverter = magicConverter.converter().getDeclaredConstructor().newInstance();
         } catch (IllegalAccessException ae) {

--- a/src/main/java/com/github/misterchangray/core/clazz/FieldParser.java
+++ b/src/main/java/com/github/misterchangray/core/clazz/FieldParser.java
@@ -162,7 +162,7 @@ public class FieldParser {
         }
 
         if(Objects.nonNull(fieldMetaInfo.getCustomConverter()) &&
-                !fieldMetaInfo.getCustomConverter().isFixsize()) {
+                !fieldMetaInfo.getCustomConverter().isFixSize()) {
             fieldMetaInfo.setElementBytes(1);
             fieldMetaInfo.setDynamic(true);
             classMetaInfo.setDynamic(true);

--- a/src/main/java/com/github/misterchangray/core/clazz/MResult.java
+++ b/src/main/java/com/github/misterchangray/core/clazz/MResult.java
@@ -18,7 +18,7 @@ public class MResult<T> {
         return bytes;
     }
 
-    public MResult setBytes(Integer bytes) {
+    public MResult<T> setBytes(Integer bytes) {
         this.bytes = bytes;
         return this;
     }
@@ -27,20 +27,20 @@ public class MResult<T> {
         return data;
     }
 
-    public MResult setData(T data) {
+    public MResult<T> setData(T data) {
         this.data = data;
         return this;
     }
 
-    public static <T> MResult build(Integer bytes, T data) {
-        MResult result = new MResult();
+    public static <T> MResult<T> build(Integer bytes, T data) {
+        MResult<T> result = new MResult<>();
         result.bytes = bytes;
         result.data = data;
         return result;
     }
 
-    public static <T> MResult build( T data) {
-        MResult result = new MResult();
+    public static <T> MResult<T> build(T data) {
+        MResult<T> result = new MResult<>();
         result.data = data;
         return result;
     }

--- a/src/main/java/com/github/misterchangray/core/custom/SimpleEnumConverter.java
+++ b/src/main/java/com/github/misterchangray/core/custom/SimpleEnumConverter.java
@@ -17,9 +17,9 @@ import com.github.misterchangray.core.intf.MConverter;
  */
 public class SimpleEnumConverter<T> implements MConverter<T> {
     @Override
-    public MResult<T> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object obj, Object root) {
         Class<Enum> enumClass = clz;
         Enum[] enumConstants = enumClass.getEnumConstants();
+    public MResult<T> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<T> clz, Object obj, Object root) {
         byte enumIndex = fullBytes[nextReadIndex];
 
         return MResult.build(1, enumConstants[enumIndex]);

--- a/src/main/java/com/github/misterchangray/core/custom/SimpleEnumConverter.java
+++ b/src/main/java/com/github/misterchangray/core/custom/SimpleEnumConverter.java
@@ -17,9 +17,9 @@ import com.github.misterchangray.core.intf.MConverter;
  */
 public class SimpleEnumConverter<T> implements MConverter<T> {
     @Override
-        Class<Enum> enumClass = clz;
-        Enum[] enumConstants = enumClass.getEnumConstants();
     public MResult<T> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<T> clz, Object obj, Object root) {
+        Class<T> enumClass = clz;
+        T[] enumConstants = enumClass.getEnumConstants();
         byte enumIndex = fullBytes[nextReadIndex];
 
         return MResult.build(1, enumConstants[enumIndex]);

--- a/src/main/java/com/github/misterchangray/core/intf/MConverter.java
+++ b/src/main/java/com/github/misterchangray/core/intf/MConverter.java
@@ -23,7 +23,7 @@ public interface MConverter<T> {
      * @param rootObj       处理的根基对象
      * @return 反序列化用的数据长度和对象
      */
-    MResult<T> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object fieldObj, Object rootObj);
+    MResult<T> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<T> clz, Object fieldObj, Object rootObj);
 
     /**
      * 将对象拆包为字节

--- a/src/main/java/com/github/misterchangray/core/intf/impl/CustomReader.java
+++ b/src/main/java/com/github/misterchangray/core/intf/impl/CustomReader.java
@@ -1,15 +1,13 @@
 package com.github.misterchangray.core.intf.impl;
 
+import com.github.misterchangray.core.clazz.CustomConverterInfo;
 import com.github.misterchangray.core.clazz.FieldMetaInfo;
 import com.github.misterchangray.core.clazz.MResult;
-import com.github.misterchangray.core.clazz.CustomConverterInfo;
-import com.github.misterchangray.core.clazz.TypeManager;
 import com.github.misterchangray.core.exception.InvalidLengthException;
 import com.github.misterchangray.core.intf.MConverter;
 import com.github.misterchangray.core.intf.MReader;
 import com.github.misterchangray.core.util.DynamicByteBuffer;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Objects;
 
 /**
@@ -36,7 +34,7 @@ public class CustomReader extends MReader {
         CustomConverterInfo converterInfo = this.fieldMetaInfo.getCustomConverter();
         MConverter converter = converterInfo.getConverter();
 
-        MResult pack = converter.pack(buffer.position(), buffer.bytes(), converterInfo.getAttachParams(), this.fieldMetaInfo.getClazz(),obj, buffer.getPackObj());
+        MResult<?> pack = converter.pack(buffer.position(), buffer.bytes(), converterInfo.getAttachParams(), this.fieldMetaInfo.getClazz(), obj, buffer.getPackObj());
 
         if ((Objects.isNull(pack) || Objects.isNull(pack.getBytes())) && !converterInfo.isFixSize()) {
             throw new InvalidLengthException(null,

--- a/src/main/java/com/github/misterchangray/core/intf/impl/CustomReader.java
+++ b/src/main/java/com/github/misterchangray/core/intf/impl/CustomReader.java
@@ -38,13 +38,13 @@ public class CustomReader extends MReader {
 
         MResult pack = converter.pack(buffer.position(), buffer.bytes(), converterInfo.getAttachParams(), this.fieldMetaInfo.getClazz(),obj, buffer.getPackObj());
 
-        if((Objects.isNull(pack) || Objects.isNull(pack.getBytes())) && !converterInfo.isFixsize()) {
+        if ((Objects.isNull(pack) || Objects.isNull(pack.getBytes())) && !converterInfo.isFixSize()) {
             throw new InvalidLengthException(null,
                     "you should return actually read bytes length when you not set fixSize property, at: " + converter.getClass().getTypeName());
         }
 
         Integer length = pack.getBytes();
-        if(Objects.nonNull(converter) && converterInfo.isFixsize()) {
+        if (Objects.nonNull(converter) && converterInfo.isFixSize()) {
             length = converterInfo.getFixSize();
         }
         int newPosition = buffer.position() + length;

--- a/src/main/java/com/github/misterchangray/core/intf/impl/CustomWriter.java
+++ b/src/main/java/com/github/misterchangray/core/intf/impl/CustomWriter.java
@@ -29,7 +29,7 @@ public class CustomWriter extends MWriter {
         CustomConverterInfo customConverter = this.fieldMetaInfo.getCustomConverter();
 
         byte[] unpack = customConverter.getConverter().unpack(val, customConverter.getAttachParams(), buffer.getPackObj());
-        int byteLen = customConverter.isFixsize() ? customConverter.getFixSize() : unpack.length;
+        int byteLen = customConverter.isFixSize() ? customConverter.getFixSize() : unpack.length;
 
         // direct write fill byte if the value is null
         byte[] data = new byte[byteLen];

--- a/src/test/java/com/github/misterchangray/core/bugtest/for47/BConvert.java
+++ b/src/test/java/com/github/misterchangray/core/bugtest/for47/BConvert.java
@@ -11,7 +11,7 @@ public      class BConvert implements MConverter<String> {
     }
 
     @Override
-    public MResult<String> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object obj, Object root) {
+    public MResult<String> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<String> clz, Object obj, Object root) {
         A a = (A) obj;
         if (a.getId() == 1) {
             return MResult.build(1,  new String(Arrays.copyOfRange(fullBytes, nextReadIndex, nextReadIndex + 1)));

--- a/src/test/java/com/github/misterchangray/core/common/converter/CustomSerialize.java
+++ b/src/test/java/com/github/misterchangray/core/common/converter/CustomSerialize.java
@@ -7,7 +7,7 @@ import com.github.misterchangray.core.intf.MConverter;
 public class CustomSerialize implements MConverter<CustomObj> {
 
     @Override
-    public MResult<CustomObj> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object tmp, Object root) {
+    public MResult<CustomObj> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<CustomObj> clz, Object tmp, Object root) {
         CustomObj customObj = new CustomObj();
         customObj.setA(fullBytes[0]);
         customObj.setB((char)fullBytes[1]);

--- a/src/test/java/com/github/misterchangray/core/common/converter/CustomSexEnumSerialize.java
+++ b/src/test/java/com/github/misterchangray/core/common/converter/CustomSexEnumSerialize.java
@@ -20,7 +20,7 @@ public class CustomSexEnumSerialize implements MConverter<SexEnum> {
      * @return 返回总共读取的字节数和封装好的对象
      */
     @Override
-    public MResult<SexEnum> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object sexEnum, Object root) {
+    public MResult<SexEnum> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<SexEnum> clz, Object sexEnum, Object root) {
         byte index = fullBytes[4];
 
         // 注意，如果没有在注解中申明`fixSize`, 这里必须要返回读取的字节数

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomArrayHandleAllConverter.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomArrayHandleAllConverter.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class CustomArrayHandleAllConverter implements MConverter<Integer[]> {
     @Override
-    public MResult<Integer[]> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object fieldObj, Object rootObj) {
+    public MResult<Integer[]> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<Integer[]> clz, Object fieldObj, Object rootObj) {
         Integer[] res = new Integer[3];
         res[0] = (Integer.valueOf( fullBytes[nextReadIndex]));
         res[1] = (Integer.valueOf( fullBytes[nextReadIndex + 1]));

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomArrayHandleAllConverter.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomArrayHandleAllConverter.java
@@ -3,16 +3,13 @@ package com.github.misterchangray.core.customconverter.customconverter;
 import com.github.misterchangray.core.clazz.MResult;
 import com.github.misterchangray.core.intf.MConverter;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class CustomArrayHandleAllConverter implements MConverter<Integer[]> {
     @Override
     public MResult<Integer[]> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<Integer[]> clz, Object fieldObj, Object rootObj) {
         Integer[] res = new Integer[3];
-        res[0] = (Integer.valueOf( fullBytes[nextReadIndex]));
-        res[1] = (Integer.valueOf( fullBytes[nextReadIndex + 1]));
-        res[2] = (Integer.valueOf( fullBytes[nextReadIndex + 2]));
+        res[0] = ((int) fullBytes[nextReadIndex]);
+        res[1] = ((int) fullBytes[nextReadIndex + 1]);
+        res[2] = ((int) fullBytes[nextReadIndex + 2]);
 
 
         return MResult.build(3, res);

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomBook3Converter.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomBook3Converter.java
@@ -1,19 +1,15 @@
 package com.github.misterchangray.core.customconverter.customconverter;
 
 import com.github.misterchangray.core.clazz.MResult;
-import com.github.misterchangray.core.customconverter.entity.Book;
 import com.github.misterchangray.core.customconverter.entity.Book3;
 import com.github.misterchangray.core.intf.MConverter;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 import java.util.Objects;
 
 public class CustomBook3Converter implements MConverter<Book3> {
     @Override
-    public MResult<Book3> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object book3, Object root) {
+    public MResult<Book3> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<Book3> clz, Object book3, Object root) {
         ByteBuffer byteBuffer = ByteBuffer.allocate(fullBytes.length);
         byteBuffer.put(fullBytes);
         byteBuffer.position(nextReadIndex);

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomBookConverter.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomBookConverter.java
@@ -3,15 +3,14 @@ package com.github.misterchangray.core.customconverter.customconverter;
 import com.github.misterchangray.core.clazz.MResult;
 import com.github.misterchangray.core.customconverter.entity.Book;
 import com.github.misterchangray.core.customconverter.entity.Book2;
-import com.github.misterchangray.core.customconverter.entity.Staff1;
+import com.github.misterchangray.core.customconverter.entity.IBook;
 import com.github.misterchangray.core.intf.MConverter;
 
-import java.math.BigInteger;
 import java.util.Date;
 
-public class CustomBookConverter implements MConverter<Book> {
+public class CustomBookConverter implements MConverter<IBook> {
     @Override
-    public MResult<Book> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object obj, Object root) {
+    public MResult<IBook> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<IBook> clz, Object obj, Object root) {
         if(attachParams[0].equals("1")) {
             Book book = new Book();
             book.setCreateDate(new Date());
@@ -43,7 +42,7 @@ public class CustomBookConverter implements MConverter<Book> {
     }
 
     @Override
-    public byte[] unpack(Book object, String[] attachParams, Object rootObj) {
+    public byte[] unpack(IBook object, String[] attachParams, Object rootObj) {
         if(attachParams[0].equals("14")) {
 
             return new byte[] {

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomConverterDynamicSize.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomConverterDynamicSize.java
@@ -4,12 +4,9 @@ import com.github.misterchangray.core.clazz.MResult;
 import com.github.misterchangray.core.customconverter.entity.Book3;
 import com.github.misterchangray.core.intf.MConverter;
 
-import java.nio.ByteBuffer;
-import java.util.Objects;
-
 public class CustomConverterDynamicSize implements MConverter<Book3> {
     @Override
-    public MResult<Book3> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object book3, Object root) {
+    public MResult<Book3> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<Book3> clz, Object book3, Object root) {
 
         Book3 book31 = new Book3();
         book31.setId(1111);

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomIntConverter.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomIntConverter.java
@@ -1,15 +1,11 @@
 package com.github.misterchangray.core.customconverter.customconverter;
 
 import com.github.misterchangray.core.clazz.MResult;
-import com.github.misterchangray.core.customconverter.entity.Book3;
 import com.github.misterchangray.core.intf.MConverter;
-
-import java.nio.ByteBuffer;
-import java.util.Objects;
 
 public class CustomIntConverter implements MConverter<Integer> {
     @Override
-    public MResult<Integer> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object staff14, Object root) {
+    public MResult<Integer> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<Integer> clz, Object staff14, Object root) {
         return MResult.build(4, 11);
     }
 

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomIntConverter2.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomIntConverter2.java
@@ -1,15 +1,11 @@
 package com.github.misterchangray.core.customconverter.customconverter;
 
 import com.github.misterchangray.core.clazz.MResult;
-import com.github.misterchangray.core.customconverter.entity.Book3;
 import com.github.misterchangray.core.intf.MConverter;
-
-import java.nio.ByteBuffer;
-import java.util.Objects;
 
 public class CustomIntConverter2 implements MConverter<Integer> {
     @Override
-    public MResult<Integer> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object staff14, Object root) {
+    public MResult<Integer> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<Integer> clz, Object staff14, Object root) {
         return MResult.build(4, 10);
     }
 

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomListHandleAllConverter.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomListHandleAllConverter.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class CustomListHandleAllConverter  implements MConverter<List<Integer>> {
     @Override
-    public MResult<List<Integer>> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object fieldObj, Object rootObj) {
+    public MResult<List<Integer>> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<List<Integer>> clz, Object fieldObj, Object rootObj) {
         List<Integer> res = new ArrayList<>();
         res.add(Integer.valueOf( fullBytes[nextReadIndex]));
         res.add(Integer.valueOf( fullBytes[nextReadIndex + 1]));

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomListHandleAllConverter.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomListHandleAllConverter.java
@@ -10,9 +10,9 @@ public class CustomListHandleAllConverter  implements MConverter<List<Integer>> 
     @Override
     public MResult<List<Integer>> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<List<Integer>> clz, Object fieldObj, Object rootObj) {
         List<Integer> res = new ArrayList<>();
-        res.add(Integer.valueOf( fullBytes[nextReadIndex]));
-        res.add(Integer.valueOf( fullBytes[nextReadIndex + 1]));
-        res.add(Integer.valueOf( fullBytes[nextReadIndex + 2]));
+        res.add((int) fullBytes[nextReadIndex]);
+        res.add((int) fullBytes[nextReadIndex + 1]);
+        res.add((int) fullBytes[nextReadIndex + 2]);
 
 
         return MResult.build(3, res);

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomStaff7Converter.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomStaff7Converter.java
@@ -8,7 +8,7 @@ import com.github.misterchangray.core.intf.MConverter;
 public  class CustomStaff7Converter implements MConverter<Staff7> {
 
     @Override
-    public MResult<Staff7> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object obj, Object root) {
+    public MResult<Staff7> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<Staff7> clz, Object obj, Object root) {
         Staff7 staff7 = new Staff7();
         staff7.setId(fullBytes[0]);
         staff7.setLength(fullBytes[1]);

--- a/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomStaff8Converter.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/customconverter/CustomStaff8Converter.java
@@ -2,14 +2,13 @@ package com.github.misterchangray.core.customconverter.customconverter;
 
 
 import com.github.misterchangray.core.clazz.MResult;
-import com.github.misterchangray.core.customconverter.entity.Staff7;
 import com.github.misterchangray.core.customconverter.entity.Staff8;
 import com.github.misterchangray.core.intf.MConverter;
 
 public  class CustomStaff8Converter implements MConverter<Staff8> {
 
     @Override
-    public MResult<Staff8> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object tmp, Object root) {
+    public MResult<Staff8> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<Staff8> clz, Object tmp, Object root) {
         Staff8 staff8 = new Staff8();
         staff8.setId(fullBytes[0]);
         staff8.setLength(fullBytes[1]);

--- a/src/test/java/com/github/misterchangray/core/customconverter/entity/Book.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/entity/Book.java
@@ -7,7 +7,7 @@ import com.github.misterchangray.core.enums.TimestampFormatter;
 import java.util.Date;
 
 @MagicClass
-public class Book {
+public class Book implements IBook {
     @MagicField(order = 1)
     private int id;
     @MagicField(order = 2, timestampFormat = TimestampFormatter.TO_TIMESTAMP_SECONDS)

--- a/src/test/java/com/github/misterchangray/core/customconverter/entity/Book2.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/entity/Book2.java
@@ -1,12 +1,8 @@
 package com.github.misterchangray.core.customconverter.entity;
 
-import com.github.misterchangray.core.annotation.MagicClass;
-import com.github.misterchangray.core.annotation.MagicField;
-import com.github.misterchangray.core.enums.TimestampFormatter;
-
 import java.util.Date;
 
-public class Book2 {
+public class Book2 implements IBook {
     private int id;
     private Date createDate;
 

--- a/src/test/java/com/github/misterchangray/core/customconverter/entity/CustomClassA.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/entity/CustomClassA.java
@@ -55,7 +55,7 @@ public class CustomClassA {
 
 
         @Override
-        public MResult<TypeEnum> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object fieldObj, Object rootObj) {
+        public MResult<TypeEnum> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<TypeEnum> clz, Object fieldObj, Object rootObj) {
             return MResult.build(1, fullBytes[nextReadIndex] == 0 ? TypeEnum.A : TypeEnum.B);
         }
 

--- a/src/test/java/com/github/misterchangray/core/customconverter/entity/CustomClassB.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/entity/CustomClassB.java
@@ -56,7 +56,7 @@ public class CustomClassB {
 
 
         @Override
-        public MResult<TypeEnum> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object fieldObj, Object rootObj) {
+        public MResult<TypeEnum> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<TypeEnum> clz, Object fieldObj, Object rootObj) {
             return MResult.build(1, fullBytes[nextReadIndex] == 0 ? TypeEnum.A : TypeEnum.B);
         }
 

--- a/src/test/java/com/github/misterchangray/core/customconverter/entity/IBook.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/entity/IBook.java
@@ -1,0 +1,9 @@
+package com.github.misterchangray.core.customconverter.entity;
+
+/**
+ * Book 的接口类
+ *
+ * @author FULaBUla
+ */
+public interface IBook {
+}

--- a/src/test/java/com/github/misterchangray/core/customconverter/entity/Staff6.java
+++ b/src/test/java/com/github/misterchangray/core/customconverter/entity/Staff6.java
@@ -59,7 +59,7 @@ public class Staff6 {
         SimpleDateFormat timestampFormatter =  new SimpleDateFormat("yyyyMMddHHmmss");
 
         @Override
-        public MResult<Date> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object obj, Object root) {
+        public MResult<Date> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<Date> clz, Object obj, Object root) {
             byte[] tmp = Arrays.copyOfRange(fullBytes, nextReadIndex, nextReadIndex + 14);
             String s = new String(tmp);
             MResult build = null;

--- a/src/test/java/com/github/misterchangray/core/protocol/bean/Protocol.java
+++ b/src/test/java/com/github/misterchangray/core/protocol/bean/Protocol.java
@@ -37,7 +37,7 @@ public class Protocol implements MConverter<MagicMessage>, MagicMessage {
     }
 
     @Override
-    public MResult<MagicMessage> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class clz, Object obj, Object root) {
+    public MResult<MagicMessage> pack(int nextReadIndex, byte[] fullBytes, String[] attachParams, Class<MagicMessage> clz, Object obj, Object root) {
         Protocol protocol = (Protocol) obj;
         switch (protocol.getHead().getCmd()) {
             case 1: return MResult.build(fullBytes.length - nextReadIndex, MagicByte.pack(Arrays.copyOfRange(fullBytes, nextReadIndex, fullBytes.length), Student.class));


### PR DESCRIPTION
close #74

# 遗留问题
类 CustomConverterInfo 的方法 MConverter getConverter()  方法返回类型 MConverter 没有增加 <?>，这里如果加上<?> 会导致 
 CustomWriter 的 doWriteToBuffer 方法无法使用 Object 作为 customConverter.getConverter().unpack 方法的入参对象，后续需要解决